### PR TITLE
Update index.md to have needed step `go mod init`

### DIFF
--- a/site/go/tutorials/cli-apps-go-cobra/creating_cli/index.md
+++ b/site/go/tutorials/cli-apps-go-cobra/creating_cli/index.md
@@ -26,6 +26,8 @@ Launch your GoLand IDE and initiate a new Go project. Specify your desired proje
 
 ![Creating a Go application](./images/1.png)
 
+If you are using the command-line, you will need to `go mod init Zero`.
+
 Create a `main.go` file within the project directory. This file will act as the central hub for your project's codebase:
 
 ![Sample of a newly created main.go file](./images/2.png)
@@ -97,7 +99,6 @@ import "Zero/cmd"
 func main() {
     cmd.Execute()
 }
-```
 
 ![Contents of main.go file](./images/6.png)
 


### PR DESCRIPTION
Help the Tutorial follower avoid errors like:

```
main.go:3:8: package Zero/cmd is not in std (/usr/local/go/src/Zero/cmd)
```
which can happen if the reader makes an incorrect assumption (such as calling it "example.com/Zero" or something else)


EDIT: If `init` was intentionally avoided for some reason, please comment as such (then I can expand on that when revising the PR, cheers.)