### PR TITLE
fix: Special characters in Markdown break HTML layout in inject_wire tutorial

### DIFF
--- a/site/go/tutorials/dependency_injection_part_two/inject_wire/index.md
+++ b/site/go/tutorials/dependency_injection_part_two/inject_wire/index.md
@@ -119,7 +119,7 @@ Finally, run the code with the GoLand run configuration by simply clicking the p
 
 ![Code run with GoLand configuration](./images/2.png)
 
-Next, select the **Run 'go build <PROJECT NAME>'** option. Your result should be similar to the image below:
+Next, select the **Run 'go build &lt;PROJECT NAME&gt;'** option. Your result should be similar to the image below:
 
 ![Code run result with GoLand configuration](./images/3.png)
 


### PR DESCRIPTION
## Description

close #19 

### Screenshots:

![image](https://github.com/user-attachments/assets/10966586-37d3-40f1-a82b-b41c959e2f6b)
